### PR TITLE
Adding a ValidationResponse property

### DIFF
--- a/docs/Griesoft.AspNetCore.ReCaptcha.xml
+++ b/docs/Griesoft.AspNetCore.ReCaptcha.xml
@@ -564,6 +564,15 @@
             A service for reCAPTCHA response back-end validation.
             </summary>
         </member>
+        <member name="P:Griesoft.AspNetCore.ReCaptcha.Services.IRecaptchaService.ValidationResponse">
+            <summary>
+            Access the validation response of the last validation that this service did perform.
+            </summary>
+            <remarks>
+            This service is registered as transient (or should be) which means the validation response will
+            always match the request that instantiated this service.
+            </remarks>
+        </member>
         <member name="M:Griesoft.AspNetCore.ReCaptcha.Services.IRecaptchaService.ValidateRecaptchaResponse(System.String,System.String)">
             <summary>
             Validate the reCAPTCHA response token.
@@ -574,6 +583,9 @@
             <exception cref="T:System.ArgumentNullException"></exception>
         </member>
         <member name="T:Griesoft.AspNetCore.ReCaptcha.Services.RecaptchaService">
+            <inheritdoc />
+        </member>
+        <member name="P:Griesoft.AspNetCore.ReCaptcha.Services.RecaptchaService.ValidationResponse">
             <inheritdoc />
         </member>
         <member name="M:Griesoft.AspNetCore.ReCaptcha.Services.RecaptchaService.ValidateRecaptchaResponse(System.String,System.String)">

--- a/src/ReCaptcha/Services/IRecaptchaService.cs
+++ b/src/ReCaptcha/Services/IRecaptchaService.cs
@@ -9,6 +9,15 @@ namespace Griesoft.AspNetCore.ReCaptcha.Services
     public interface IRecaptchaService
     {
         /// <summary>
+        /// Access the validation response of the last validation that this service did perform.
+        /// </summary>
+        /// <remarks>
+        /// This service is registered as transient (or should be) which means the validation response will
+        /// always match the request that instantiated this service.
+        /// </remarks>
+        ValidationResponse? ValidationResponse { get; }
+
+        /// <summary>
         /// Validate the reCAPTCHA response token.
         /// </summary>
         /// <param name="token">The response token.</param>

--- a/src/ReCaptcha/Services/RecaptchaService.cs
+++ b/src/ReCaptcha/Services/RecaptchaService.cs
@@ -29,6 +29,9 @@ namespace Griesoft.AspNetCore.ReCaptcha.Services
         }
 
         /// <inheritdoc />
+        public ValidationResponse? ValidationResponse { get; private set; }
+
+        /// <inheritdoc />
         public async Task<ValidationResponse> ValidateRecaptchaResponse(string token, string? remoteIp = null)
         {
             _ = token ?? throw new ArgumentNullException(nameof(token));
@@ -40,7 +43,7 @@ namespace Griesoft.AspNetCore.ReCaptcha.Services
 
                 response.EnsureSuccessStatusCode();
 
-                return JsonConvert.DeserializeObject<ValidationResponse>(
+                ValidationResponse = JsonConvert.DeserializeObject<ValidationResponse>(
                     await response.Content.ReadAsStringAsync()
                     .ConfigureAwait(true))
                     ?? new ValidationResponse()
@@ -55,7 +58,7 @@ namespace Griesoft.AspNetCore.ReCaptcha.Services
             catch (HttpRequestException)
             {
                 _logger.ValidationRequestFailed();
-                return new ValidationResponse()
+                ValidationResponse = new ValidationResponse()
                 {
                     Success = false,
                     ErrorMessages = new List<string>()
@@ -69,6 +72,8 @@ namespace Griesoft.AspNetCore.ReCaptcha.Services
                 _logger.ValidationRequestUnexpectedException(ex);
                 throw;
             }
+
+            return ValidationResponse;
         }
     }
 }

--- a/tests/ReCaptcha.Tests/Services/RecaptchaServiceTests.cs
+++ b/tests/ReCaptcha.Tests/Services/RecaptchaServiceTests.cs
@@ -164,5 +164,21 @@ namespace ReCaptcha.Tests.Services
             Assert.IsTrue(response.Success);
             Assert.AreEqual(0, response.Errors.Count());
         }
+
+        [Test]
+        public async Task ValidateRecaptchaResponse_Should_DeserializedResponse_AndSet_ValidationResponseProperty()
+        {
+            // Arrange
+            var service = new RecaptchaService(_settingsMock.Object, _httpClient, _logger);
+
+            // Act
+            var response = await service.ValidateRecaptchaResponse(Token);
+
+            // Assert
+            _httpMessageHandlerMock.Verify();
+            Assert.IsTrue(response.Success);
+            Assert.AreEqual(0, response.Errors.Count());
+            Assert.NotNull(service.ValidationResponse);
+        }
     }
 }


### PR DESCRIPTION
I am adding a ValidationResponse property to the `IRecaptchaService`. This property provides access to the latest validation response if one exists.

This can be useful in cases where one did not have the chance to capture the response in an Action for example. 

The default `IRecaptchaService` is registered as transient service. This ensures that each request has only access to the validation response of its own service instance.

Custom implementation of `IRecaptchaService` should avoid being registered as singletons.