### PR TITLE
Register IRecaptchaService as scoped to DI

### DIFF
--- a/docs/Griesoft.AspNetCore.ReCaptcha.xml
+++ b/docs/Griesoft.AspNetCore.ReCaptcha.xml
@@ -68,6 +68,11 @@
             The section name in the appsettings.json from which the settings are read.
             </summary>
         </member>
+        <member name="F:Griesoft.AspNetCore.ReCaptcha.Configuration.RecaptchaServiceConstants.RecaptchaServiceHttpClientName">
+            <summary>
+            The named HttpClient name that we use in the IRecpatchaService.
+            </summary>
+        </member>
         <member name="T:Griesoft.AspNetCore.ReCaptcha.Configuration.RecaptchaSettings">
             <summary>
             Mandatory settings for this reCAPTCHA service. The values for this object will be read from your appsettings.json file.

--- a/docs/Griesoft.AspNetCore.ReCaptcha.xml
+++ b/docs/Griesoft.AspNetCore.ReCaptcha.xml
@@ -4,6 +4,70 @@
         <name>Griesoft.AspNetCore.ReCaptcha</name>
     </assembly>
     <members>
+        <member name="T:System.Diagnostics.CodeAnalysis.AllowNullAttribute">
+            <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.DisallowNullAttribute">
+            <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.MaybeNullAttribute">
+            <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.NotNullAttribute">
+            <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute">
+            <summary>Specifies that when a method returns <see cref="P:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute.ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute.#ctor(System.Boolean)">
+            <summary>Initializes the attribute with the specified return value condition.</summary>
+            <param name="returnValue">
+            The return value condition. If the method returns this value, the associated parameter may be null.
+            </param>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute.ReturnValue">
+            <summary>Gets the return value condition.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute">
+            <summary>Specifies that when a method returns <see cref="P:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute.ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute.#ctor(System.Boolean)">
+            <summary>Initializes the attribute with the specified return value condition.</summary>
+            <param name="returnValue">
+            The return value condition. If the method returns this value, the associated parameter will not be null.
+            </param>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute.ReturnValue">
+            <summary>Gets the return value condition.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute">
+            <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute.#ctor(System.String)">
+            <summary>Initializes the attribute with the associated parameter name.</summary>
+            <param name="parameterName">
+            The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+            </param>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute.ParameterName">
+            <summary>Gets the associated parameter name.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute">
+            <summary>Applied to a method that will never return under any circumstance.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute">
+            <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute.#ctor(System.Boolean)">
+            <summary>Initializes the attribute with the specified parameter value.</summary>
+            <param name="parameterValue">
+            The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+            the associated parameter matches this value.
+            </param>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute.ParameterValue">
+            <summary>Gets the condition parameter value.</summary>
+        </member>
         <member name="T:Griesoft.AspNetCore.ReCaptcha.Configuration.RecaptchaOptions">
             <summary>
             Options for this reCAPTCHA service. You can set your global default values for the service on app startup.

--- a/src/ReCaptcha/Configuration/RecaptchaServiceConstants.cs
+++ b/src/ReCaptcha/Configuration/RecaptchaServiceConstants.cs
@@ -24,5 +24,10 @@
         /// The section name in the appsettings.json from which the settings are read.
         /// </summary>
         public const string SettingsSectionKey = "RecaptchaSettings";
+
+        /// <summary>
+        /// The named HttpClient name that we use in the IRecpatchaService.
+        /// </summary>
+        public const string RecaptchaServiceHttpClientName = "ReCaptchaValidationClient";
     }
 }

--- a/src/ReCaptcha/Extensions/RecaptchaServiceExtensions.cs
+++ b/src/ReCaptcha/Extensions/RecaptchaServiceExtensions.cs
@@ -26,10 +26,12 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.Configure(options ??= opt => { });
 
-            services.AddHttpClient<IRecaptchaService, RecaptchaService>(client =>
+            services.AddHttpClient(RecaptchaServiceConstants.RecaptchaServiceHttpClientName, client =>
             {
                 client.BaseAddress = new Uri(RecaptchaServiceConstants.GoogleRecaptchaEndpoint);
             });
+
+            services.AddScoped<IRecaptchaService, RecaptchaService>();
 
             services.AddTransient<IValidateRecaptchaFilter, ValidateRecaptchaFilter>();
 

--- a/src/ReCaptcha/Services/RecaptchaService.cs
+++ b/src/ReCaptcha/Services/RecaptchaService.cs
@@ -17,14 +17,14 @@ namespace Griesoft.AspNetCore.ReCaptcha.Services
     internal class RecaptchaService : IRecaptchaService
     {
         private readonly RecaptchaSettings _settings;
-        private readonly HttpClient _httpClient;
+        private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<RecaptchaService> _logger;
 
         public RecaptchaService(IOptionsMonitor<RecaptchaSettings> settings,
-            HttpClient httpClient, ILogger<RecaptchaService> logger)
+            IHttpClientFactory httpClientFactory, ILogger<RecaptchaService> logger)
         {
             _settings = settings.CurrentValue;
-            _httpClient = httpClient;
+            _httpClientFactory = httpClientFactory;
             _logger = logger;
         }
 
@@ -38,7 +38,8 @@ namespace Griesoft.AspNetCore.ReCaptcha.Services
 
             try
             {
-                var response = await _httpClient.PostAsync($"?secret={_settings.SecretKey}&response={token}{(remoteIp != null ? $"&remoteip={remoteIp}" : "")}", null!)
+                var httpClient = _httpClientFactory.CreateClient(RecaptchaServiceConstants.RecaptchaServiceHttpClientName);
+                var response = await httpClient.PostAsync($"?secret={_settings.SecretKey}&response={token}{(remoteIp != null ? $"&remoteip={remoteIp}" : "")}", null!)
                     .ConfigureAwait(true);
 
                 response.EnsureSuccessStatusCode();

--- a/tests/ReCaptcha.Tests/Extensions/RecaptchaServiceExtensionsTests.cs
+++ b/tests/ReCaptcha.Tests/Extensions/RecaptchaServiceExtensionsTests.cs
@@ -17,8 +17,8 @@ namespace ReCaptcha.Tests.Extensions
             services.AddRecaptchaService();
 
             // Assert
-            Assert.IsTrue(services.Any(service => service.ServiceType.FullName == "Griesoft.AspNetCore.ReCaptcha.Services.IRecaptchaService"));
-            Assert.IsTrue(services.Any(service => service.ServiceType.FullName == "Griesoft.AspNetCore.ReCaptcha.Filters.IValidateRecaptchaFilter"));
+            Assert.IsTrue(services.Any(service => service.ServiceType.FullName == "Griesoft.AspNetCore.ReCaptcha.Services.IRecaptchaService" && service.Lifetime == ServiceLifetime.Scoped));
+            Assert.IsTrue(services.Any(service => service.ServiceType.FullName == "Griesoft.AspNetCore.ReCaptcha.Filters.IValidateRecaptchaFilter" && service.Lifetime == ServiceLifetime.Transient));
             Assert.IsTrue(services.Any(service => service.ServiceType.FullName == "Microsoft.Extensions.Options.IConfigureOptions`1[[Griesoft.AspNetCore.ReCaptcha.Configuration.RecaptchaOptions, Griesoft.AspNetCore.ReCaptcha, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"));
             Assert.IsTrue(services.Any(service => service.ServiceType.FullName == "Microsoft.Extensions.Options.IConfigureOptions`1[[Griesoft.AspNetCore.ReCaptcha.Configuration.RecaptchaSettings, Griesoft.AspNetCore.ReCaptcha, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"));
         }

--- a/tests/ReCaptcha.Tests/Services/RecaptchaServiceTests.cs
+++ b/tests/ReCaptcha.Tests/Services/RecaptchaServiceTests.cs
@@ -95,6 +95,19 @@ namespace ReCaptcha.Tests.Services
         }
 
         [Test]
+        public async Task ValidateRecaptchaResponse_Should_CreateNamedHttpClient()
+        {
+            // Arrange
+            var service = new RecaptchaService(_settingsMock.Object, _httpClientFactory.Object, _logger);
+
+            // Act
+            var response = await service.ValidateRecaptchaResponse(Token);
+
+            // Assert
+            _httpClientFactory.Verify();
+        }
+
+        [Test]
         public async Task ValidateRecaptchaResponse_ShouldReturn_HttpRequestError()
         {
             // Arrange
@@ -118,8 +131,7 @@ namespace ReCaptcha.Tests.Services
 
             _httpClientFactory = new Mock<IHttpClientFactory>();
             _httpClientFactory.Setup(instance => instance.CreateClient(It.Is<string>(val => val == RecaptchaServiceConstants.RecaptchaServiceHttpClientName)))
-                .Returns(_httpClient)
-                .Verifiable();
+                .Returns(_httpClient);
 
             var service = new RecaptchaService(_settingsMock.Object, _httpClientFactory.Object, _logger);
 
@@ -128,7 +140,6 @@ namespace ReCaptcha.Tests.Services
 
             // Assert
             _httpMessageHandlerMock.Verify();
-            _httpClientFactory.Verify();
             Assert.GreaterOrEqual(response.Errors.Count(), 1);
             Assert.AreEqual(ValidationError.HttpRequestFailed, response.Errors.First());
         }
@@ -154,8 +165,7 @@ namespace ReCaptcha.Tests.Services
 
             _httpClientFactory = new Mock<IHttpClientFactory>();
             _httpClientFactory.Setup(instance => instance.CreateClient(It.Is<string>(val => val == RecaptchaServiceConstants.RecaptchaServiceHttpClientName)))
-                .Returns(_httpClient)
-                .Verifiable();
+                .Returns(_httpClient);
 
             var service = new RecaptchaService(_settingsMock.Object, _httpClientFactory.Object, _logger);
 
@@ -165,7 +175,6 @@ namespace ReCaptcha.Tests.Services
             // Assert
             Assert.ThrowsAsync<Exception>(() => service.ValidateRecaptchaResponse(Token));
             _httpMessageHandlerMock.Verify();
-            _httpClientFactory.Verify();
         }
 
         [Test]
@@ -194,7 +203,6 @@ namespace ReCaptcha.Tests.Services
 
             // Assert
             _httpMessageHandlerMock.Verify();
-            _httpClientFactory.Verify();
             Assert.IsTrue(response.Success);
             Assert.AreEqual(0, response.Errors.Count());
             Assert.NotNull(service.ValidationResponse);


### PR DESCRIPTION
With the addition of the `ValidationResponse` property, I noticed that registering the service as transient will make this property useless.

This is why we register the service as scoped now. This will make sure we receive the same instance for one request/connection.

This change should not introduce any breaking changes.